### PR TITLE
Add the Flatpak talk name

### DIFF
--- a/org.kde.kile.json
+++ b/org.kde.kile.json
@@ -12,6 +12,7 @@
         "--socket=wayland",
         "--device=dri",
         "--filesystem=home",
+        "--talk-name=org.freedesktop.Flatpak",
         "--env=PATH=/app/bin:/app/texlive/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux:/usr/bin/"
     ],
     "separate-locales": false,


### PR DESCRIPTION
Kile is using flatpak-spawn through its konsole component and without this it explodes. Also it doesn't work as expected since the konsole will show the wrong OS view. https://invent.kde.org/frameworks/kcoreaddons/-/merge_requests/276