### PR TITLE
Fix TeXLive paths for Perl

### DIFF
--- a/kile.sh
+++ b/kile.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+if [ -d /app/texlive/bin ] && [ -d /app/texlive/lib ]; then
+    cd /app/texlive/lib/perl5/site_perl
+    perl_version=$(ls)
+    arch=$(uname -m)
+    # Add paths of TeX Live Flatpak extension binaries
+    export PATH=$PATH:/app/texlive/bin:/app/texlive/bin/$arch-linux
+    # Add include paths for Perl @INC variable
+    export PERL5LIB=/app/texlive/lib/perl5/$perl_version:/app/texlive/lib/perl5/site_perl/$perl_version
+    # Add library paths
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/texlive/lib:/app/texlive/lib/perl5/$perl_version/$arch-linux/CORE
+else
+    echo "warning: missing required extension: org.freedesktop.Sdk.Extension.texlive"
+fi
+
+cd # This is required to avoid Kile closing with "Program to run not set."
+exec kile "$@"

--- a/org.kde.kile.json
+++ b/org.kde.kile.json
@@ -3,7 +3,7 @@
     "runtime": "org.kde.Platform",
     "runtime-version": "5.15-22.08",
     "sdk": "org.kde.Sdk",
-    "command": "kile",
+    "command": "kile.sh",
     "rename-icon": "kile",
     "finish-args": [
         "--share=ipc",
@@ -12,8 +12,7 @@
         "--socket=wayland",
         "--device=dri",
         "--filesystem=home",
-        "--talk-name=org.freedesktop.Flatpak",
-        "--env=PATH=/app/bin:/app/texlive/bin:/app/texlive/bin/x86_64-linux:/app/texlive/bin/aarch64-linux:/usr/bin/"
+        "--talk-name=org.freedesktop.Flatpak"
     ],
     "separate-locales": false,
     "add-extensions": {
@@ -568,10 +567,15 @@
                 {
                     "type": "patch",
                     "path": "appstream-metadata-fix.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "kile.sh"
                 }
             ],
             "post-install": [
-                "install -d /app/texlive"
+                "install -d /app/texlive",
+                "install -Dm755 -t /app/bin/ ./kile.sh"
             ]
         }
     ]


### PR DESCRIPTION
Changes in `org.freedesktop.Sdk.Extension.texlive` have moved the Perl installation around, resulting in it being absent from bin/lib paths. This causes Perl-requiring components, such as `biber` for bibliographies, to silently fail. Similar issues were encountered in other Flatpak'ed TeX editors:

- TeXstudio: https://github.com/flathub/org.texstudio.TeXstudio/issues/138
- Texmaker: https://github.com/flathub/net.xm1math.Texmaker/pull/17

One challenge with this approach is the hard-coded Perl version, TeXstudio has solved this with a startup script: https://github.com/flathub/org.texstudio.TeXstudio/blob/d21b95d88c03c2a92c7f3f5e37acb01d94f7c265/texstudio.sh. Would that be preferred here as well?