### PR TITLE
Fix bibliography backend autodetection

### DIFF
--- a/acbc530666d7607df45784992d021cf1e60724d6.patch
+++ b/acbc530666d7607df45784992d021cf1e60724d6.patch
@@ -1,0 +1,25 @@
+From acbc530666d7607df45784992d021cf1e60724d6 Mon Sep 17 00:00:00 2001
+From: Samuel Jimenez <the.real.samuel.jimenez@gmail.com>
+Date: Tue, 26 Mar 2024 13:38:53 -0500
+Subject: [PATCH] Make warning RegEx non-greedy.
+
+---
+ src/parser/latexoutputparser.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/parser/latexoutputparser.cpp b/src/parser/latexoutputparser.cpp
+index 2c2dbed42..7a0cfe6f1 100644
+--- a/src/parser/latexoutputparser.cpp
++++ b/src/parser/latexoutputparser.cpp
+@@ -410,7 +410,7 @@ bool LaTeXOutputParser::detectWarning(const QString & strLine, short &dwCookie)
+     bool found = false, flush = false;
+     QString warning;
+ 
+-    static QRegularExpression reLaTeXWarning("^(((! )?(La|pdf)TeX)|Package|Class) .*Warning.*:(.*)", QRegularExpression::CaseInsensitiveOption);
++    static QRegularExpression reLaTeXWarning("^(((! )?(La|pdf)TeX)|Package|Class) .*Warning.*?:(.*)", QRegularExpression::CaseInsensitiveOption);
+     static QRegularExpression reNoFile("No file (.*)");
+     static QRegularExpression reNoAsyFile("File .* does not exist."); // FIXME can be removed when https://sourceforge.net/p/asymptote/bugs/70/ has promoted to the users
+ 
+-- 
+GitLab
+

--- a/d8195e931782e39014450d7d508bddd349eb28f1.patch
+++ b/d8195e931782e39014450d7d508bddd349eb28f1.patch
@@ -1,0 +1,28 @@
+From d8195e931782e39014450d7d508bddd349eb28f1 Mon Sep 17 00:00:00 2001
+From: Dennis Marttinen <twelho@welho.tech>
+Date: Mon, 16 Sep 2024 12:59:48 +0300
+Subject: [PATCH] Find bibliography tools using base names
+
+This fixes one of the bugs highlighted in https://bugs.kde.org/show_bug.cgi?id=408890, namely that Biber (or any other bibliography backend) can't be configured with an absolute path if desired to be picked up by the automatic detection. The issue stems from comparing the user's input (e.g., `/usr/bin/biber`) to the backend name (e.g., `Biber`) case-insentively, but literally. Changing this to use the base name of the tool command instead resolves the issue.
+---
+ src/kiletoolmanager.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/kiletoolmanager.cpp b/src/kiletoolmanager.cpp
+index 55763ee40..16d1b92b6 100644
+--- a/src/kiletoolmanager.cpp
++++ b/src/kiletoolmanager.cpp
+@@ -687,8 +687,8 @@ KileTool::ToolConfigPair KileTool::Manager::findFirstBibliographyToolForCommand(
+ {
+     // for now we will just select the first suitable tool
+     for(const KileTool::ToolConfigPair& tool : m_bibliographyToolsList) {
+-        const QString toolCommand = commandFor(tool, m_config);
+-        if (QString::compare(command, toolCommand, Qt::CaseInsensitive) == 0) {
++        const QFileInfo toolCommand(commandFor(tool, m_config));
++        if (QString::compare(command, toolCommand.baseName(), Qt::CaseInsensitive) == 0) {
+             return tool;
+         }
+     }
+-- 
+GitLab
+

--- a/org.kde.kile.json
+++ b/org.kde.kile.json
@@ -646,6 +646,14 @@
                 {
                     "type": "patch",
                     "path": "appdata.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "acbc530666d7607df45784992d021cf1e60724d6.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "d8195e931782e39014450d7d508bddd349eb28f1.patch"
                 }
             ],
             "post-install": [


### PR DESCRIPTION
This pulls in the changes from https://invent.kde.org/office/kile/-/merge_requests/85 and https://invent.kde.org/office/kile/-/merge_requests/102, which have not made their way into a release yet. The first MR fixes the bibliography backend detection logic, which is especially imporant for BibLaTeX projects using Biber instead of BibTeX. The second MR augments this by also enabling a full path to Biber (or any other backend) to be specified and still be correctly picked up. Kile doesn't seem to have gotten a release in some time, which is why I'm suggesting carrying the patches here in the meantime, since these bugs are a dealbreaker for workflows, see, e.g., https://bugs.kde.org/show_bug.cgi?id=307437 and https://bugs.kde.org/show_bug.cgi?id=408890. Once a new release is tagged, these patches can be removed.