### PR TITLE
Fix TeX Live Perl paths again

### DIFF
--- a/kile.sh
+++ b/kile.sh
@@ -2,12 +2,24 @@
 
 if [ -d /app/texlive/bin ] && [ -d /app/texlive/lib ]; then
     arch=$(uname -m)
-    # Add paths of TeX Live Flatpak extension binaries
-    export PATH=$PATH:/app/texlive/bin:/app/texlive/bin/$arch-linux
+
+    # Find the Perl version of the TeX Live Flatpak extension
+    perl_version=$(find /app/texlive/lib/perl5 -type f -name libperl.so | head -1 | awk -F/ '{print $6}')
+    if [ -z "$perl_version" ]; then
+        echo "error: unable to resolve org.freedesktop.Sdk.Extension.texlive perl5 version" >&2
+	exit 1
+    fi
+
+    # Add paths of TeX Live binaries
+    export PATH="$PATH":/app/texlive/bin:/app/texlive/bin/"$arch"-linux
+
     # Add library paths
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/texlive/lib
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH":/app/texlive/lib:/app/texlive/lib/perl5/"$perl_version"/"$arch"-linux/CORE
+
+    # Add Perl paths
+    export PERL5LIB=/app/texlive/lib/perl5/"$perl_version":/app/texlive/lib/perl5/site_perl
 else
-    echo "warning: missing required extension: org.freedesktop.Sdk.Extension.texlive"
+    echo "warning: missing required extension: org.freedesktop.Sdk.Extension.texlive" >&2
 fi
 
 cd # This is required to avoid Kile closing with "Program to run not set."


### PR DESCRIPTION
Changes in `org.freedesktop.Sdk.Extension.texlive` have once again changed and broken the Perl paths, which TeX Live tools such as `biber` depend on (ref. https://github.com/flathub/org.kde.kile/pull/210). The [current instructions](https://github.com/flathub/org.freedesktop.Sdk.Extension.texlive/blob/8942e396f7c442721a19e01c41da914bda5882cd/README.md) tell to configure some more paths in `LD_LIBRARY_PATH` and also set `PERL5LIB`, I've updated `kile.sh` to match this behavior. The official guidance also suggests to use hard-coded Perl-version-dependent paths, which we can instead locate dynamically in a relatively robust way. Together with https://github.com/flathub/org.kde.kile/pull/273, `biber` works again as expected.